### PR TITLE
feat: add GitHub Actions workflow and ubuntu binary distribution

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,42 @@
+name: Release fosslight_scanner_gui
+
+on:
+  release:
+    types: [published]
+
+jobs:
+    build:
+        name: Build packages
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            include:
+              - os: ubuntu-latest
+                TARGET: ubuntu
+                CMD_BUILD: >
+                    yarn &&
+                    yarn build &&
+                    tar -czf fosslight-gui-ubuntu-setup.tar.gz -C dist/linux-unpacked .
+                OUT_FILE_NAME: fosslight-gui-ubuntu-setup.tar.gz
+                ASSET_MIME: application/gzip
+        steps:
+        - uses: actions/checkout@v3
+        - name: Set up Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version: '18'
+        - name: Install dependencies
+          run: |
+            yarn install
+        - name: Build with yarn for ${{ matrix.TARGET }}
+          run: ${{ matrix.CMD_BUILD }}
+        - name: Upload Release Asset
+          id: upload-release-asset
+          uses: actions/upload-release-asset@v1.0.1
+          env:
+            GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          with:
+            upload_url: ${{ github.event.release.upload_url }}
+            asset_path: ./${{ matrix.OUT_FILE_NAME }}
+            asset_name: ${{ matrix.OUT_FILE_NAME }}
+            asset_content_type: ${{ matrix.ASSET_MIME }}


### PR DESCRIPTION
## Description
Use GitHub Actions to implement Ubuntu binary file distribution in FOSSLight Scanner Gui. The deployment process is triggered on new releases.

### Changes
Add New GitHub Actions Workflow for Ubuntu Binary File Deployment

### Benefits
Automatically add compressed tar.gz files to assets at release to run binary files for Ubuntu

### Testing
Verified workflow triggers correctly on new releases

### Additional Notes
Windows and Macos binary file distribution will be requested separately by Pull Request.

Please review and provide feedback. Let me know if any additional changes or information are needed.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
