### PR TITLE
Add windows build

### DIFF
--- a/.github/workflows/.github/workflows/main.yml
+++ b/.github/workflows/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: Release fosslight_scanner_gui
+
+on:
+  release:
+    types: [published]
+
+jobs:
+    build:
+        name: Build packages
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            include:
+              - os: ubuntu-latest
+                TARGET: ubuntu
+                CMD_BUILD: >
+                    yarn &&
+                    yarn build &&
+                    tar -czf fosslight-gui-ubuntu-setup.tar.gz -C dist/linux-unpacked .
+                OUT_FILE_NAME: fosslight-gui-ubuntu-setup.tar.gz
+                ASSET_MIME: application/gzip
+              - os: windows-latest
+                TARGET: windows
+                CMD_BUILD: >
+                    yarn &&
+                    yarn build &&
+                    yarn electron-builder --win --x64
+                OUT_FILE_NAME: fosslight-gui-windows-setup.exe
+                ASSET_MIME: application/vnd.microsoft.portable-executable
+        steps:
+        - uses: actions/checkout@v3
+        - name: Set up Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version: '18'
+        - name: Install dependencies
+          run: |
+            yarn install
+        - name: Build with yarn for ${{ matrix.TARGET }}
+          run: ${{ matrix.CMD_BUILD }}
+        - name: Upload Release Asset
+          id: upload-release-asset
+          uses: actions/upload-release-asset@v1.0.1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ github.event.release.upload_url }}
+            asset_path: ./${{ matrix.OUT_FILE_NAME }}
+            asset_name: ${{ matrix.OUT_FILE_NAME }}
+            asset_content_type: ${{ matrix.ASSET_MIME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: Release fosslight_scanner_gui
+
+on:
+  release:
+    types: [published]
+
+jobs:
+    build:
+        name: Build packages
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            include:
+              - os: ubuntu-latest
+                TARGET: ubuntu
+                CMD_BUILD: >
+                    yarn &&
+                    yarn build &&
+                    tar -czf fosslight-gui-ubuntu-setup.tar.gz -C dist/linux-unpacked .
+                OUT_FILE_NAME: fosslight-gui-ubuntu-setup.tar.gz
+                ASSET_MIME: application/gzip
+        steps:
+        - uses: actions/checkout@v3
+        - name: Set up Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version: '18'
+        - name: Install dependencies
+          run: |
+            yarn install
+        - name: Build with yarn for ${{ matrix.TARGET }}
+          run: ${{ matrix.CMD_BUILD }}
+        - name: Upload Release Asset
+          id: upload-release-asset
+          uses: actions/upload-release-asset@v1.0.1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ github.event.release.upload_url }}
+            asset_path: ./${{ matrix.OUT_FILE_NAME }}
+            asset_name: ${{ matrix.OUT_FILE_NAME }}
+            asset_content_type: ${{ matrix.ASSET_MIME }}


### PR DESCRIPTION
## Description
This PR adds a new workflow to the GitHub Actions configuration to support building Windows executables. It introduces a new build job for Windows and updates the workflow to handle Windows-specific build tasks.


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
