### PR TITLE
Add window.exe steps to publish-release.yml

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,9 +24,9 @@ jobs:
                 CMD_BUILD: >
                   yarn &&
                   yarn build &&
-                  move dist/your_executable.exe fosslight-gui-windows.exe
-                OUT_FILE_NAME: fosslight-gui-windows.exe
-                ASSET_MIME: application/octet-stream
+                  powershell Compress-Archive -Path dist\* -DestinationPath fosslight-gui-windows-setup.zip
+                OUT_FILE_NAME: fosslight-gui-windows-setup.zip
+                ASSET_MIME: application/zip
               
               
         steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,15 @@ jobs:
                     tar -czf fosslight-gui-ubuntu-setup.tar.gz -C dist/linux-unpacked .
                 OUT_FILE_NAME: fosslight-gui-ubuntu-setup.tar.gz
                 ASSET_MIME: application/gzip
+              - os: windows-latest
+                TARGET: windows
+                CMD_BUILD: >
+                  yarn &&
+                  yarn build &&
+                  tar -czf fosslight-gui-windows-setup.tar.gz -C dist .
+                OUT_FILE_NAME: fosslight-gui-windows-setup.tar.gz
+                ASSET_MIME: application/gzip
+              
         steps:
         - uses: actions/checkout@v3
         - name: Set up Node.js

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,9 +24,10 @@ jobs:
                 CMD_BUILD: >
                   yarn &&
                   yarn build &&
-                  tar -czf fosslight-gui-windows-setup.tar.gz -C dist .
-                OUT_FILE_NAME: fosslight-gui-windows-setup.tar.gz
-                ASSET_MIME: application/gzip
+                  move dist/your_executable.exe fosslight-gui-windows.exe
+                OUT_FILE_NAME: fosslight-gui-windows.exe
+                ASSET_MIME: application/octet-stream
+              
               
         steps:
         - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
This PR adds a new workflow to automate the release process for Windows executable files. The `publish-release.yml` file has been created in the `.github/workflows` directory to define the steps for building and publishing a Windows `.exe` file as part of the release process. This includes defining the build steps and ensuring that the `.exe` file is included in the GitHub release when a new tag is pushed.



## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
