### PR TITLE
Add Windows EXE Release Support to FOSSLight Scanner GUI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,7 +65,7 @@ jobs:
       id: upload-release-asset
       uses: actions/upload-release-asset@v1.0.1
       env:
-        GITHUB_TOKEN: ${{ secrets.TOKEN }}    
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}    
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ./fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.${{ matrix.TARGET == 'ubuntu' && 'tar.gz' || matrix.TARGET == 'macos' && 'zip' || 'zip' }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,28 +17,50 @@ jobs:
           - os: macos-latest
             TARGET: macos
             ASSET_MIME: application/zip
+          - os: windows-latest
+            TARGET: windows
+            ASSET_MIME: application/vnd.microsoft.portable-executable
     steps:
     - uses: actions/checkout@v3
     - name: Get the version
       id: get_version
       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      shell: bash
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
         node-version: '18'
     - name: Install dependencies
       run: yarn install
+    - name: Clean previous build
+      run: npm run clean
     - name: Build with yarn for ${{ matrix.TARGET }}
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
         if [ "${{ matrix.TARGET }}" == "ubuntu" ]; then
           yarn build
-          tar -czf fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.tar.gz -C dist/linux-unpacked .
+          sleep 5
+          tar -czf fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}-temp.tar.gz -C dist/linux-unpacked .
+          mv fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}-temp.tar.gz fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.tar.gz
         elif [ "${{ matrix.TARGET }}" == "macos" ]; then
           yarn build:mac
-          ditto -c -k --sequesterRsrc --keepParent "dist/mac/fosslight_gui.app" fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.zip
+          sleep 5
+          ditto -c -k --sequesterRsrc --keepParent "dist/mac/fosslight_gui.app" fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}-temp.zip
+          mv fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}-temp.zip fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.zip
+          echo "current location..."
+          pwd
+        elif [ "${{ matrix.TARGET }}" == "windows" ]; then
+          yarn build:win
+          sleep 5
+          7z a -tzip ./fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}-temp.zip ./dist/win-unpacked/*
+          mv ./fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}-temp.zip ./fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.zip
+          echo "Listing dist directory..."
+          ls ./dist
+          echo "current location..."
+          pwd
         fi
+      shell: bash
     - name: Upload Release Asset
       id: upload-release-asset
       uses: actions/upload-release-asset@v1.0.1
@@ -46,6 +68,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.TOKEN }}    
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.${{ matrix.TARGET == 'ubuntu' && 'tar.gz' || 'zip' }}
-        asset_name: fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.${{ matrix.TARGET == 'ubuntu' && 'tar.gz' || 'zip' }}
+        asset_path: ./fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.${{ matrix.TARGET == 'ubuntu' && 'tar.gz' || matrix.TARGET == 'macos' && 'zip' || 'zip' }}
+        asset_name: fosslight-gui-${{ matrix.TARGET }}-setup-${{ env.VERSION }}.${{ matrix.TARGET == 'ubuntu' && 'tar.gz' || matrix.TARGET == 'macos' && 'zip' || 'zip' }}
         asset_content_type: ${{ matrix.ASSET_MIME }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,7 +9,9 @@ files:
   - '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
   - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
+  - "out/**/*"
 win:
+  artifactName: ${name}-${version}-${arch}-win.${ext}
   executableName: fosslight_gui
   target:
     - target: nsis
@@ -21,7 +23,7 @@ win:
         - x64
         - arm64
 nsis:
-  artifactName: ${name}-${version}-setup.${ext}
+  artifactName: ${name}-${version}-${arch}-win-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
@@ -30,6 +32,7 @@ nsis:
   perMachine: false
   allowToChangeInstallationDirectory: true
 mac:
+  artifactName: ${name}-${version}-${arch}-mac.${ext}
   target:
     - target: zip
       arch:
@@ -40,7 +43,6 @@ mac:
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
-    - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: false
 linux:
   target:
@@ -58,7 +60,7 @@ linux:
   maintainer: https://github.com/fosslight/fosslight_gui
   synopsis: FOSSLight Scanner GUI Application
   category: Utility
-  artifactName: ${name}-${version}-${arch}.${ext}
+  artifactName: ${name}-${version}-${arch}-linux.${ext}
 snap:
   base: core20
   publish:

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "dev": "electron-vite dev --watch",
     "build": "npm run typecheck && electron-vite build && electron-builder --dir",
     "build:mac": "electron-vite build && electron-builder --mac --config electron-builder.yml",
+    "build:win": "npm run typecheck && electron-vite build && electron-builder build --win --config electron-builder.yml",
     "postinstall": "electron-builder install-app-deps",
     "release:win": "npm run typecheck && electron-vite build && electron-builder --win --config electron-builder.yml",
     "release:mac": "npm run typecheck && electron-vite build && electron-builder --mac --config electron-builder.yml",
     "release:linux-rpm-tar": "npm run typecheck && electron-vite build && electron-builder --linux rpm tar.gz --x64 --armv7l --arm64",
-    "release:linux-deb-snap": "npm run typecheck && electron-vite build && electron-builder --linux --config electron-builder.yml"
+    "release:linux-deb-snap": "npm run typecheck && electron-vite build && electron-builder --linux --config electron-builder.yml",
+    "clean": "rimraf dist"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.0",
@@ -51,6 +53,7 @@
     "react-dom": "^18.2.0",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.3.3",
-    "vite": "^5.0.12"
+    "vite": "^5.0.12",
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
## Description
This pull request adds support for building and releasing Windows executable files for the FOSSLight Scanner GUI. It includes modifications to the build process, GitHub Actions workflow, and related configuration files to enable automatic creation and publishing of Windows EXE files during the release process.

### Changes Made

- Updated electron-builder.yml to include Windows-specific build configurations
- Modified publish-release.yml GitHub Actions workflow to handle Windows builds
- Adjusted package.json scripts for Windows build support
- Added necessary dependencies and configurations for Windows builds

## Testing Performed

Tested the build process locally on a Windows machine
Verified the created Windows executable file runs correctly
Checked the GitHub Actions workflow for successful completion of Windows builds

### correct released picture
![image](https://github.com/user-attachments/assets/9b565e7f-d2f8-41f3-b450-31c30e3fa836)


## Additional Notes

This PR completes the multi-platform support for FOSSLight Scanner GUI, enabling releases for Windows alongside existing macOS and Linux support
Reviewers should pay special attention to the Windows-specific configurations and build steps


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
